### PR TITLE
fix: actually send DISCONNECT message before closing socket

### DIFF
--- a/nyamuk/nyamuk.py
+++ b/nyamuk/nyamuk.py
@@ -152,6 +152,8 @@ class Nyamuk(base_nyamuk.BaseNyamuk):
         self.state = NC.CS_DISCONNECTING
         
         ret = self.send_disconnect()
+        ret2, bytes_written = self.packet_write()
+
         self.socket_close()
         return ret
     


### PR DESCRIPTION
when calling disconnect() method, DISCONNECT packet is created and queued, but never sent before closing the socket