### PR TITLE
feat: implement SSL transport

### DIFF
--- a/nyamuk/base_nyamuk.py
+++ b/nyamuk/base_nyamuk.py
@@ -15,13 +15,15 @@ MQTTCONNECT = 16# 1 << 4
 class BaseNyamuk:
     """Base class of nyamuk."""
     def __init__(self, client_id, username, password,
-                 server, port, keepalive):
+                 server, port, keepalive, ssl, ssl_opts):
         ''' Constructor '''
         self.client_id = client_id
         self.username = username
         self.password = password
         self.server = server
         self.port = port
+        self.ssl = ssl
+        self.ssl_opts = ssl_opts
         
         self.address = ""
         self.keep_alive = keepalive
@@ -54,7 +56,6 @@ class BaseNyamuk:
         self.log_destinations = -1
         
         self.host = None
-        self.port = 1883
         
         #hack var
         self.as_broker = False

--- a/nyamuk/nyamuk.py
+++ b/nyamuk/nyamuk.py
@@ -145,7 +145,11 @@ class Nyamuk(base_nyamuk.BaseNyamuk):
             opts.update(self.ssl_opts)
             #print opts, self.port
 
-            self.sock = ssl.wrap_socket(self.sock, **opts)
+            try:
+                self.sock = ssl.wrap_socket(self.sock, **opts)
+            except Exception, e:
+                self.logger.error("failed to initiate SSL connection: {0}".format(e))
+                return NC.ERR_UNKNOWN
 
         nyamuk_net.setkeepalives(self.sock)
         

--- a/nyamuk/nyamuk_net.py
+++ b/nyamuk/nyamuk_net.py
@@ -2,6 +2,7 @@
 Nyamuk networking module.
 Copyright(c) 2012 Iwan Budi Kusnanto
 """
+import ssl
 import socket
 import errno
 
@@ -17,8 +18,10 @@ def connect(sock, addr):
     """Connect to some addr."""
     try:
         sock.connect(addr)
-    except socket.error as (_, msg):
-        return (socket.error, msg)
+    except ssl.SSLError as e:
+        return (ssl.SSLError, e.strerror if e.strerror else e.message)
+    except socket.error as e:
+        return (socket.error, e.strerror if e.strerror else e.message)
     except socket.herror as (_, msg):
         return (socket.herror, str)
     except socket.gaierror as (_, msg):
@@ -34,6 +37,8 @@ def read(sock, count):
     """
     try:
         data = sock.recv(count)
+    except ssl.SSLError as e:
+        return data, e.errno, e.strerror if strerror else e.message
     except socket.error as (errnum, errmsg):
         return data, errnum, errmsg
     except socket.herror as (errnum, errmsg):
@@ -54,6 +59,8 @@ def write(sock, payload):
     """Write payload to socket."""
     try:
         length = sock.send(payload)
+    except ssl.SSLError as e:
+        return -1, (ssl.SSLError, e.strerror if strerror else e.message)
     except socket.error as (_, msg):
         return -1, (socket.error, msg)
     except socket.herror as (_, msg):


### PR DESCRIPTION
Allow to use SSL as transport for MQTT messages
i.e:
```python
import ssl
client = nyamul.Nyamuk("test", None, None, "localhost", 
   ssl=True,
   ssl_opts={
      'ssl_version': ssl.PROTOCOL_TLSv1
   }
)
```